### PR TITLE
Remove Hardcoded API Token

### DIFF
--- a/app/main/util/get_demographics.py
+++ b/app/main/util/get_demographics.py
@@ -16,18 +16,21 @@ url = 'https://graphql.cherre.com/graphql'
 file_dir = ''  # Must include trailing slash. If left blank, 
 # csv will be created in the current directory.
 api_email='lukeowentruitt@gmail.com'
-api_token ='Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJHcmFwaFFMIFRva2VuIiwibmFtZSI6IiIsImh0dHBzOi8vaGFzdXJhLmlvL2p3dC9jbGFpbXMiOnsieC1oYXN1cmEtYWxsb3dlZC1yb2xlcyI6WyJ0Ml9kZXZlbG9wbWVudCJdLCJ4LWhhc3VyYS1kZWZhdWx0LXJvbGUiOiJ0Ml9kZXZlbG9wbWVudCIsIngtaGFzdXJhLXVzZXItaWQiOiJ0Ml9kZXZlbG9wbWVudCIsIngtaGFzdXJhLW9yZy1pZCI6InQyX2RldmVsb3BtZW50In19.sjHOw5oF3vYb3S_dxhWT7ucJ1qvQccDaHbyjzLkrKQQ'
+api_token = os.getenv("CHERRE_API_TOKEN")
+if not api_token:
+    raise ValueError("Need to define CHERRE_API_TOKEN environment variable")
+auth_header_value = 'Bearer ' + api_token
 api_account='Luke Truitt'
 
 def get_graphql_request (Query):
-    headers = {'content-type': 'application/json', 'X-Auth-Email': api_email, 'Authorization': api_token}
+    headers = {'content-type': 'application/json', 'X-Auth-Email': api_email, 'Authorization': auth_header_value}
     # This variable replacement requires Python3.6 or higher
     payload = {"query": Query}
     r = requests.request("POST",url, json=payload, headers=headers)
     return r
 
 def get_graphql_request_variables (Query,Variables):
-    headers = {'content-type': 'application/json', 'X-Auth-Email': api_email, 'Authorization': api_token}
+    headers = {'content-type': 'application/json', 'X-Auth-Email': api_email, 'Authorization': auth_header_value}
     # This variable replacement requires Python3.6 or higher
     payload = {"query": Query, "variables": Variables}
     r = requests.request("POST",url, json=payload, headers=headers)

--- a/app/main/util/lasso_scores/location_score.py
+++ b/app/main/util/lasso_scores/location_score.py
@@ -33,7 +33,10 @@ url = 'https://graphql.cherre.com/graphql'
 file_dir = ''  # Must include trailing slash. If left blank, 
 # csv will be created in the current directory.
 api_email='lukeowentruitt@gmail.com'
-api_token ='Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJHcmFwaFFMIFRva2VuIiwibmFtZSI6IiIsImh0dHBzOi8vaGFzdXJhLmlvL2p3dC9jbGFpbXMiOnsieC1oYXN1cmEtYWxsb3dlZC1yb2xlcyI6WyJ0Ml9kZXZlbG9wbWVudCJdLCJ4LWhhc3VyYS1kZWZhdWx0LXJvbGUiOiJ0Ml9kZXZlbG9wbWVudCIsIngtaGFzdXJhLXVzZXItaWQiOiJ0Ml9kZXZlbG9wbWVudCIsIngtaGFzdXJhLW9yZy1pZCI6InQyX2RldmVsb3BtZW50In19.sjHOw5oF3vYb3S_dxhWT7ucJ1qvQccDaHbyjzLkrKQQ'
+api_token = os.getenv("CHERRE_API_TOKEN")
+if not api_token:
+    raise ValueError("Need to define CHERRE_API_TOKEN environment variable")
+auth_header_value = 'Bearer ' + api_token
 api_account='Luke Truitt'
 
 dict_poi_nd=dict()
@@ -41,14 +44,14 @@ dict_poi_id_poi=dict()
 fips='48453'
 
 def get_graphql_request (Query):
-    headers = {'content-type': 'application/json', 'X-Auth-Email': api_email, 'Authorization': api_token}
+    headers = {'content-type': 'application/json', 'X-Auth-Email': api_email, 'Authorization': auth_header_value}
     # This variable replacement requires Python3.6 or higher
     payload = {"query": Query}
     r = requests.request("POST",url, json=payload, headers=headers)
     return r
 
 def get_graphql_request_variables (Query,Variables):
-    headers = {'content-type': 'application/json', 'X-Auth-Email': api_email, 'Authorization': api_token}
+    headers = {'content-type': 'application/json', 'X-Auth-Email': api_email, 'Authorization': auth_header_value}
     # This variable replacement requires Python3.6 or higher
     payload = {"query": Query, "variables": Variables}
     r = requests.request("POST",url, json=payload, headers=headers)

--- a/app/main/util/points_of_interest.py
+++ b/app/main/util/points_of_interest.py
@@ -33,18 +33,21 @@ url = 'https://graphql.cherre.com/graphql'
 file_dir = ''  # Must include trailing slash. If left blank, 
 # csv will be created in the current directory.
 api_email='lukeowentruitt@gmail.com'
-api_token ='Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJHcmFwaFFMIFRva2VuIiwibmFtZSI6IiIsImh0dHBzOi8vaGFzdXJhLmlvL2p3dC9jbGFpbXMiOnsieC1oYXN1cmEtYWxsb3dlZC1yb2xlcyI6WyJ0Ml9kZXZlbG9wbWVudCJdLCJ4LWhhc3VyYS1kZWZhdWx0LXJvbGUiOiJ0Ml9kZXZlbG9wbWVudCIsIngtaGFzdXJhLXVzZXItaWQiOiJ0Ml9kZXZlbG9wbWVudCIsIngtaGFzdXJhLW9yZy1pZCI6InQyX2RldmVsb3BtZW50In19.sjHOw5oF3vYb3S_dxhWT7ucJ1qvQccDaHbyjzLkrKQQ'
+api_token = os.getenv("CHERRE_API_TOKEN")
+if not api_token:
+    raise ValueError("Need to define CHERRE_API_TOKEN environment variable")
+auth_header_value = 'Bearer ' + api_token
 api_account='Luke Truitt'
 
 def get_graphql_request (Query):
-    headers = {'content-type': 'application/json', 'X-Auth-Email': api_email, 'Authorization': api_token}
+    headers = {'content-type': 'application/json', 'X-Auth-Email': api_email, 'Authorization': auth_header_value}
     # This variable replacement requires Python3.6 or higher
     payload = {"query": Query}
     r = requests.request("POST",url, json=payload, headers=headers)
     return r
 
 def get_graphql_request_variables (Query,Variables):
-    headers = {'content-type': 'application/json', 'X-Auth-Email': api_email, 'Authorization': api_token}
+    headers = {'content-type': 'application/json', 'X-Auth-Email': api_email, 'Authorization': auth_header_value}
     # This variable replacement requires Python3.6 or higher
     payload = {"query": Query, "variables": Variables}
     r = requests.request("POST",url, json=payload, headers=headers)

--- a/app/main/util/scrape_property.py
+++ b/app/main/util/scrape_property.py
@@ -24,18 +24,21 @@ url = 'https://graphql.cherre.com/graphql'
 file_dir = ''  # Must include trailing slash. If left blank, 
 # csv will be created in the current directory.
 api_email='lukeowentruitt@gmail.com'
-api_token ='Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJHcmFwaFFMIFRva2VuIiwibmFtZSI6IiIsImh0dHBzOi8vaGFzdXJhLmlvL2p3dC9jbGFpbXMiOnsieC1oYXN1cmEtYWxsb3dlZC1yb2xlcyI6WyJ0Ml9kZXZlbG9wbWVudCJdLCJ4LWhhc3VyYS1kZWZhdWx0LXJvbGUiOiJ0Ml9kZXZlbG9wbWVudCIsIngtaGFzdXJhLXVzZXItaWQiOiJ0Ml9kZXZlbG9wbWVudCIsIngtaGFzdXJhLW9yZy1pZCI6InQyX2RldmVsb3BtZW50In19.sjHOw5oF3vYb3S_dxhWT7ucJ1qvQccDaHbyjzLkrKQQ'
+api_token = os.getenv("CHERRE_API_TOKEN")
+if not api_token:
+    raise ValueError("Need to define CHERRE_API_TOKEN environment variable")
+auth_header_value = 'Bearer ' + api_token
 api_account='Luke Truitt'
 
 def get_graphql_request (Query):
-    headers = {'content-type': 'application/json', 'X-Auth-Email': api_email, 'Authorization': api_token}
+    headers = {'content-type': 'application/json', 'X-Auth-Email': api_email, 'Authorization': auth_header_value}
     # This variable replacement requires Python3.6 or higher
     payload = {"query": Query}
     r = requests.request("POST",url, json=payload, headers=headers)
     return r
 
 def get_graphql_request_variables (Query,Variables):
-    headers = {'content-type': 'application/json', 'X-Auth-Email': api_email, 'Authorization': api_token}
+    headers = {'content-type': 'application/json', 'X-Auth-Email': api_email, 'Authorization': auth_header_value}
     # This variable replacement requires Python3.6 or higher
     payload = {"query": Query, "variables": Variables}
     r = requests.request("POST",url, json=payload, headers=headers)


### PR DESCRIPTION
# What

Remove hardcoded API token

# Why

Exposing third-party credentials like that :
- is a bad security practice
- undermines trust in your software and your company
- gets the credentials you exposed invalidated in a heartbeat
- potentially violates the conditions of your customer/trial agreement
- causes security audit findings for you and for the third party whose credentials you exposed

# Notes

- It is not enough to accept the changes in this PR as the exposed credentials will remain in git history. Please refer to [Removing sensitive data from a repository](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository) for full remediation
  - Alternatively, you can make the repository private/internal
- You can use [sops](https://github.com/getsops/sops) or alternatives to keep the credential in the repo in the encrypted form (e.g. an encrypted `envs` file that contains the value for the environment variable)
- Can you please take action within two weeks?
- Disclaimer: the author of this PR works for Cherre
